### PR TITLE
Update rspack.config.js

### DIFF
--- a/basic-react/rspack.config.js
+++ b/basic-react/rspack.config.js
@@ -22,7 +22,6 @@ module.exports = {
         exclude: [/[\\/]node_modules[\\/]/],
         loader: "builtin:swc-loader",
         options: {
-          sourceMap: true,
           jsc: {
             parser: {
               syntax: "typescript",
@@ -39,7 +38,6 @@ module.exports = {
         loader: "builtin:swc-loader",
         exclude: [/[\\/]node_modules[\\/]/],
         options: {
-          sourceMap: true,
           jsc: {
             parser: {
               syntax: "typescript",


### PR DESCRIPTION
Fix warning:

```
Invalid configuration object. Rspack has been initialized using a configuration object that does not match the API schema.
- Expected value to be "..." at "module.rules[0]" or Invalid options for 'builtin:swc-loader': unrecognized key(s) "sourceMap" in object at "module.rules[0]" or Expected value to be false at "module.rules[0]" or Expected value to be 0 at "module.rules[0]" or Expected value to be "" at "module.rules[0]" or Expected null at "module.rules[0]" or Expected undefined at "module.rules[0]"
- Expected value to be "..." at "module.rules[1]" or Invalid options for 'builtin:swc-loader': unrecognized key(s) "sourceMap" in object at "module.rules[1]" or Expected value to be false at "module.rules[1]" or Expected value to be 0 at "module.rules[1]" or Expected value to be "" at "module.rules[1]" or Expected null at "module.rules[1]" or Expected undefined at "module.rules[1]"
```

See: https://github.com/web-infra-dev/rspack/issues/10241

> The `builtin:swc-loader` of Rspack will always parse source map to object so I think you can just remove this option. In previous version of Rspack, this option was not recognized and enabled.