### PR TITLE
fix: missing `@swc/helpers`

### DIFF
--- a/basic-react/package.json
+++ b/basic-react/package.json
@@ -3,6 +3,7 @@
   "dependencies": {
     "@iconify-icons/material-symbols": "^1.2.58",
     "@iconify/react": "^6.0.0",
+    "@swc/helpers": "^0.5.17",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       '@iconify/react':
         specifier: ^6.0.0
         version: 6.0.0(react@19.1.0)
+      '@swc/helpers':
+        specifier: ^0.5.17
+        version: 0.5.17
       react:
         specifier: ^19.0.0
         version: 19.1.0
@@ -38,6 +41,9 @@ packages:
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
+  '@swc/helpers@0.5.17':
+    resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
+
   react-dom@19.1.0:
     resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
     peerDependencies:
@@ -49,6 +55,9 @@ packages:
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
 snapshots:
 
@@ -63,6 +72,10 @@ snapshots:
 
   '@iconify/types@2.0.0': {}
 
+  '@swc/helpers@0.5.17':
+    dependencies:
+      tslib: 2.8.1
+
   react-dom@19.1.0(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -71,3 +84,5 @@ snapshots:
   react@19.1.0: {}
 
   scheduler@0.26.0: {}
+
+  tslib@2.8.1: {}


### PR DESCRIPTION
Fix error in compilation:

```
x Module not found: Can't resolve '@swc/helpers/_/_type_of' in '/Users/
  | colin/rspack/.bench/rspack-benchcases/node_modules/.pnpm/react-
  | dom@19.1.0_react@19.1.0/node_modules/react-dom/cjs'
    ,-[10:31]
  9 |  */ "use strict";
 10 | import { _ as _type_of } from "@swc/helpers/_/_type_of";
    :                               ^^^^^^^^^^^^^^^^^^^^^^^^^
 11 | "production" !== process.env.NODE_ENV && function() {
    `----
```