### PR TITLE
fix: should alias `@swc/helpers`

### DIFF
--- a/basic-react/rspack.config.js
+++ b/basic-react/rspack.config.js
@@ -6,6 +6,9 @@ const prod = process.env.NODE_ENV === "production";
 /** @type {import("@rspack/cli").Configuration} */
 module.exports = {
   resolve: {
+    alias: {
+      "@swc/helpers": require.resolve("@swc/helpers"),
+    },
     extensions: [".js", ".jsx"],
   },
   entry: { main: "./src/index.jsx" },


### PR DESCRIPTION
Following up #3, I forgot to make an alias for `@swc/helpers` since it could occur in `node_modules` like `react-dom`.