### PR TITLE
fix: alias `@swc/helpers` in threejs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,11 @@ importers:
         specifier: ^19.0.0
         version: 19.1.0(react@19.1.0)
 
-  threejs: {}
+  threejs:
+    dependencies:
+      '@swc/helpers':
+        specifier: ^0.5.17
+        version: 0.5.17
 
 packages:
 

--- a/threejs/package.json
+++ b/threejs/package.json
@@ -1,3 +1,6 @@
 {
-  "name": "threejs"
+  "name": "threejs",
+  "dependencies": {
+    "@swc/helpers": "^0.5.17"
+  }
 }

--- a/threejs/rspack.config.js
+++ b/threejs/rspack.config.js
@@ -1,4 +1,9 @@
 /** @type {import("@rspack/cli").Configuration} */
 module.exports = {
-	entry: { main: "./src/Three.js" }
+  entry: { main: "./src/Three.js" },
+  resolve: {
+    alias: {
+      "@swc/helpers": require.resolve("@swc/helpers"),
+    },
+  },
 };


### PR DESCRIPTION
Yet another error :)

```
x Module not found: Can't resolve '@swc/helpers/_/_instanceof' in '/Users/
  | colin/rspack/.bench/rspack-benchcases/threejs/src/renderers/webgl'
   ,-[3:38]
 2 |  * @author mrdoob / http://mrdoob.com/
 3 |  */ import { _ as _instanceof } from "@swc/helpers/_/_instanceof";
   :                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 4 | import { LinearFilter, NearestFilter, RGBFormat, RGBAFormat, DepthFormat, DepthStencilFormat, UnsignedShortType, UnsignedIntType, UnsignedInt248Type, FloatType, HalfFloatType, ClampToEdgeWrapping, NearestMipmapLinearFilter, NearestMipmapNearestFilter } from '../../constants.js';
```