### PR TITLE
Revert "fix: alias `@swc/helpers` in threejs"

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,11 +26,7 @@ importers:
         specifier: ^19.0.0
         version: 19.1.0(react@19.1.0)
 
-  threejs:
-    dependencies:
-      '@swc/helpers':
-        specifier: ^0.5.17
-        version: 0.5.17
+  threejs: {}
 
 packages:
 

--- a/threejs/package.json
+++ b/threejs/package.json
@@ -1,6 +1,3 @@
 {
-  "name": "threejs",
-  "dependencies": {
-    "@swc/helpers": "^0.5.17"
-  }
+  "name": "threejs"
 }

--- a/threejs/rspack.config.js
+++ b/threejs/rspack.config.js
@@ -1,9 +1,4 @@
 /** @type {import("@rspack/cli").Configuration} */
 module.exports = {
-  entry: { main: "./src/Three.js" },
-  resolve: {
-    alias: {
-      "@swc/helpers": require.resolve("@swc/helpers"),
-    },
-  },
+	entry: { main: "./src/Three.js" }
 };


### PR DESCRIPTION
Reverts rspack-contrib/rspack-benchcases#5

The SWC helpers should be inlined by default. This is a bug of Rspack, which should be fixed by  https://github.com/web-infra-dev/rspack/pull/11108.